### PR TITLE
Fix Swiss federal supreme court name

### DIFF
--- a/auto-ch.json
+++ b/auto-ch.json
@@ -35,7 +35,7 @@
     "ch": {
       "institution-part": {
         "fcc": "Bundesstrafgericht",
-        "fsc": "Sweizerisches Bundesgericht"
+        "fsc": "Schweizerisches Bundesgericht"
       }
     },
     "ch:aargau": {


### PR DESCRIPTION
Same as https://github.com/Juris-M/jurism-abbreviations/pull/4 which got reverted by https://github.com/Juris-M/jurism-abbreviations/commit/3b1bb036d285efcb706264224a2f966ab5001222